### PR TITLE
Update Zippyshare to 500MB limit

### DIFF
--- a/zippyshare.sh
+++ b/zippyshare.sh
@@ -185,8 +185,8 @@ zippyshare_upload() {
     local PAGE SERVER FORM_HTML FORM_ACTION FORM_UID FILE_URL FORM_DATA_AUTH
 
     local SZ=$(get_filesize "$FILE")
-    if [ "$SZ" -gt 209715200 ]; then
-        log_debug 'file is bigger than 200MB'
+    if [ "$SZ" -gt 524288000 ]; then
+        log_debug 'file is bigger than 500MB'
         return $ERR_SIZE_LIMIT_EXCEEDED
     fi
 


### PR DESCRIPTION
Zippyshare now supports uploads till 500MB